### PR TITLE
Make complete working set of scripts (#2, #41, #42)

### DIFF
--- a/run/WRF-Chem/jobscript_wrfchem.sh
+++ b/run/WRF-Chem/jobscript_wrfchem.sh
@@ -12,12 +12,11 @@
 
 
 #-------- Input --------
-CASENAME='WRF_CHEM_TEST_MOZARTMOSAIC'
-CASENAME_COMMENT=''
+CASENAME='WRF_CHEM_TEST'
+CASENAME_COMMENT='MOZART_MOSAIC'
 
 # Root directory with the compiled WRF executables (main/wrf.exe and main/real.exe)
 WRFDIR=~/WRF/src/WRF-Chem-Polar/WRFV4
-WRFVERSION='chem.develop'
 
 # Simulation start year and month
 yys=2012
@@ -61,8 +60,13 @@ date_e="$yye-$mme-$dde"
 # Run id
 ID="$(date +"%Y%m%d").$SLURM_JOBID"
 
+# Case name for the output folder
+if [ -n "$CASENAME_COMMENT" ]; then
+  CASENAME_COMMENT="_${CASENAME_COMMENT}"
+fi
+
 # Directory containing real output (e.g. wrfinput_d01, wrfbdy_d01 files)
-REALDIR="${INDIR_ROOT}/real_${CASENAME}_$(date -d "$date_s" "+%Y")"
+REALDIR="${INDIR_ROOT}/real_${CASENAME}${CASENAME_COMMENT}_$(date -d "$date_s" "+%Y")"
 # Directory containing WRF-Chem output
 OUTDIR="${OUTDIR_ROOT}/DONE.${CASENAME}${CASENAME_COMMENT}.$ID"
 mkdir "$OUTDIR"
@@ -77,7 +81,7 @@ cd "$SCRATCH" || exit
 echo " "
 echo "-------- $SLURM_JOB_NAME --------"
 echo "Running from $date_s to $date_e"
-echo "Running version wrf.exe.$WRFVERSION from $WRFDIR"
+echo "Running version wrf.exe from $WRFDIR"
 echo "Running on scratchdir $SCRATCH"
 echo "Writing output to $OUTDIR"
 echo "Input files from real.exe taken from $REALDIR"
@@ -94,8 +98,7 @@ cd "$SCRATCH" || exit
 cp "$SLURM_SUBMIT_DIR/"* "$SCRATCH/"
 # Executables and WRF aux files from WRFDIR
 cp "$WRFDIR/run/"* "$SCRATCH/"
-# We run the version wrf.exe.$WRFVERSION in $WRFDIR/../executables
-cp "$WRFDIR/../executables/wrf.exe.$WRFVERSION" "$SCRATCH/wrf.exe"
+cp "$WRFDIR/main/wrf.exe" "$SCRATCH/wrf.exe"
 
 #  Copy and prepare the WRF namelist, set up run start and end dates
 cp "$SLURM_SUBMIT_DIR/${NAMELIST}" namelist.input

--- a/run/real/jobscript_real.sh
+++ b/run/real/jobscript_real.sh
@@ -16,7 +16,6 @@ CASENAME_COMMENT='MOZARTMOSAIC'
 
 # Root directory with the compiled WRF executables (main/wrf.exe and main/real.exe)
 WRFDIR=~/WRF/src/WRF-Chem-Polar/WRFV4
-WRFVERSION='chem.develop'
 
 # Simulation start year and month
 yys=2012
@@ -87,7 +86,7 @@ cd "$SCRATCH" || exit
 echo " "
 echo "-------- $SLURM_JOB_NAME: Launch real.exe and preprocessors --------"
 echo "Running from $date_s to $date_e"
-echo "Running version real.exe.$WRFVERSION from $WRFDIR"
+echo "Running version real.exe from $WRFDIR"
 echo "Running on scratchdir $SCRATCH"
 echo "Writing output to $REALDIR"
 echo "Input files from WPS taken from $WPSDIR"
@@ -104,7 +103,7 @@ cd "$SCRATCH" || exit
 cp "$SLURM_SUBMIT_DIR/"* "$SCRATCH/"
 # Executables and WRF aux files from WRFDIR
 cp "$WRFDIR/run/"* "$SCRATCH/"
-cp "$WRFDIR/../executables/real.exe.$WRFVERSION" "$SCRATCH/real.exe" || exit
+cp "$WRFDIR/main/real.exe" "$SCRATCH/real.exe" || exit
 # met_em WPS files from WPSDIR
 cp "${WPSDIR}/met_em.d"* "$SCRATCH/" || exit
 
@@ -238,13 +237,12 @@ else
 fi
 tail fire_emis.out
 
-#---- Run the matlab anthro emission preprocessor (create wrfchemi* files)
+#---- Run the python anthro emission preprocessor (create wrfchemi* files)
 echo " "
 echo "-------- $SLURM_JOB_NAME: run emission script --------"
 echo " "
-module load matlab
-#TODO replace by CAMS or give choice
-matlab -nodisplay -singleCompThread -nodesktop -r "prep_anthro_emissions_mozartmosaic_eclipse_rcp(datenum($yys,$mms,$dds),datenum($yye,$mme,$dde));exit" > prep_anthro_emissions.out
+cp "$SLURM_SUBMIT_DIR/cams2wrfchem.py" "$SCRATCH/"
+python -u cams2wrfchem.py --start ${date_s} --end ${date_e} --domain 1
 
 #---- Initialize snow on sea ice
 echo " "

--- a/run/real/namelist.input.YYYY
+++ b/run/real/namelist.input.YYYY
@@ -78,7 +78,8 @@
 ! min time step (s) needs to be = the resolution (km)
  min_time_step                       = 100,15,3,
  adaptation_domain                   = 1,
- /
+ wif_input_opt                       = 1,
+/
 
  &physics
 ! Microphysics options


### PR DESCRIPTION
This PR fixes a few minor things that were preventing a successful run up to now. Summary:
* use CAMS emissions instead of ECLIPSE, since we already have a python script for pre-processing CAMS whereas for ECLIPSE a matlab script not in this repo was required
* change file paths to real.exe and wrf.exe (#42)
* make REALDIR definition consistent in jobscript_real and jobscript_wrf
* add wif_input_opt=1 to namelist.input (required for vn4.6, throws error in real and WRF-Chem if not included) (related to #41)